### PR TITLE
Feature/do not force jsonapi header

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,15 @@ Metrics/BlockLength:
 Layout/LineLength:
   Max: 80
 
+Lint/EmptyClass:
+  Enabled: false
+
 Naming/FileName:
   Exclude:
     - lib/shark-on-lambda.rb
     - spec/shark-on-lambda_spec.rb
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
 
 # TODO: Add documentation and remove the Style/Documentation exception.
 Style/Documentation:

--- a/lib/shark-on-lambda.rb
+++ b/lib/shark-on-lambda.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/string'
 require 'active_support/deprecation'
 
 deprecation_message = <<-MESSAGE.squish
-  Requiring `shark-on-lambda` is deprecated and will be removed in version 3.0. 
+  Requiring `shark-on-lambda` is deprecated and will be removed in version 3.
   Please require `shark_on_lambda` instead.
 MESSAGE
 ActiveSupport::Deprecation.warn(deprecation_message, caller(2))

--- a/lib/shark_on_lambda/base_controller.rb
+++ b/lib/shark_on_lambda/base_controller.rb
@@ -22,7 +22,7 @@ module SharkOnLambda
     end
 
     ActionController::Renderers.add :jsonapi do |object, options|
-      response.set_header('content-type', 'application/vnd.api+json')
+      response.content_type = 'application/vnd.api+json; charset=utf-8'
       return { data: {} }.to_json if object.nil?
 
       jsonapi_renderer = JsonapiRenderer.new(object)
@@ -50,15 +50,6 @@ module SharkOnLambda
       super
 
       self.response_body = no_body? ? nil : { data: {} }.to_json
-    end
-
-    def render(object, options = {})
-      options.merge!(
-        jsonapi: object,
-        content_type: 'application/vnd.api+json'
-      )
-
-      super(options)
     end
 
     private

--- a/lib/shark_on_lambda/errors/base.rb
+++ b/lib/shark_on_lambda/errors/base.rb
@@ -36,7 +36,7 @@ module SharkOnLambda
       end
       class_name_parts = message.to_s.split(/\s+/)
       class_name_parts.map! { |word| word.gsub(/[^a-z]/i, '').capitalize }
-      class_name = class_name_parts.join('')
+      class_name = class_name_parts.join
       const_set(class_name, error_class)
 
       [status_code, error_class]

--- a/shark-on-lambda.gemspec
+++ b/shark-on-lambda.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '1.11.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end

--- a/spec/factories/api_gateway.rb
+++ b/spec/factories/api_gateway.rb
@@ -22,8 +22,8 @@ FactoryBot.define do
     end
     multiValueQueryStringParameters do
       {
-        'foo': %w[foo],
-        'bar': %w[bar baz],
+        foo: %w[foo],
+        bar: %w[bar baz],
         'top[nested][nested_value]': %w[value],
         'top[nested][nested_array][]': %w[1]
       }

--- a/spec/test_application/app/controllers/test_application/base_controller.rb
+++ b/spec/test_application/app/controllers/test_application/base_controller.rb
@@ -6,7 +6,7 @@ module TestApplication
     after_action :after_action_method
 
     rescue_from HandledException do |e|
-      render SharkOnLambda::Errors[400].new(e.message), status: 400
+      render jsonapi: SharkOnLambda::Errors[400].new(e.message) , status: 400
     end
 
     def invalid_redirect
@@ -14,7 +14,7 @@ module TestApplication
     end
 
     def render_nil
-      render nil
+      render jsonapi: nil
     end
 
     def redirect_once
@@ -46,7 +46,7 @@ module TestApplication
     # end
 
     def render_unserializable
-      render Object.new
+      render jsonapi: Object.new
     end
 
     def explode_with_handled_exception

--- a/spec/test_application/app/controllers/test_application/base_controller.rb
+++ b/spec/test_application/app/controllers/test_application/base_controller.rb
@@ -6,7 +6,7 @@ module TestApplication
     after_action :after_action_method
 
     rescue_from HandledException do |e|
-      render jsonapi: SharkOnLambda::Errors[400].new(e.message) , status: 400
+      render jsonapi: SharkOnLambda::Errors[400].new(e.message), status: 400
     end
 
     def invalid_redirect


### PR DESCRIPTION
This pull request replaces Skudo/shark-on-lambda/pull/4.

1) It removes the override of `#render` to allow different content types aside from `application/vnd.api+json`.

2) Fixes setting content type `application/vnd.api+json` in the `:jsonapi` renderer.

3) Fix `rubocop` version